### PR TITLE
Some changes on voucher valid time

### DIFF
--- a/database/tables.sql
+++ b/database/tables.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS `vouchers` (
   `valid_until` int(11) NOT NULL,
   `verification_key` varchar(255),
   `comment` varchar(255) NOT NULL,
+   `valid_for` INT(11) NOT NULL,
   PRIMARY KEY (`voucher_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 

--- a/src/admin/addvoucher.php
+++ b/src/admin/addvoucher.php
@@ -26,10 +26,12 @@ if((is_numeric($_POST['cnt']) && trim($_POST['cnt'])!='') && ($_POST['d']!=0 || 
 	if(!is_numeric($_POST['dev-cnt'])) $_POST['dev-cnt']=1; // Has the user enterered a numeric value for the device count?
 	
 	$voucher_ids=array();
-	$valid_until=time()+($_POST['d']*86400)+($_POST['h']*3600)+($_POST['m']*60); // Calculate expiration time
+	//$valid_until=time()+($_POST['d']*86400)+($_POST['h']*3600)+($_POST['m']*60); // Calculate expiration time
+	$valid_until=strtotime("+2 years"); // Voucher valid until +2 years from now, if not use
+	$valid_for=($_POST['d']*24)+($_POST['h']); // Calculate expiration time
 	for($i=1;$i<=$_POST['cnt'];$i++)
 	{
-		array_push($voucher_ids,$v->MakeVoucher($_POST['dev-cnt'],$valid_until,$_POST['comment']));
+		array_push($voucher_ids,$v->MakeVoucher($_POST['dev-cnt'],$valid_until,$_POST['comment'],$valid_for));
 	}
 	echo '<center><b>The voucher(s) have been issued.</b></center><br><br>';
 	if($_POST['print']=='y')
@@ -48,8 +50,8 @@ if((is_numeric($_POST['cnt']) && trim($_POST['cnt'])!='') && ($_POST['d']!=0 || 
 	How many vouchers do you want to create?<br>
 	<input type="text" class="formstyle" name="cnt" size="2" value="10"> pieces (enter amount)<br><br>
 	How long shall the voucher be valid?<br>
-	<input type="text" class="formstyle" name="d" size="2" value="0"> days, <input type="text" class="formstyle" name="h" size="2" value="4"> hours, 
-	<input type="text" class="formstyle" name="m" size="2" value="0"> minutes
+	<input type="text" class="formstyle" name="d" size="2" value="0"> days, <input type="text" class="formstyle" name="h" size="2" value="4"> hours. 
+	
 	<br><br>
 	How many devices may the user register with this voucher?<br>
 	<input type="text" class="formstyle" name="dev-cnt" size="2" value="3"> devices<br><br>

--- a/src/classes/gui.php
+++ b/src/classes/gui.php
@@ -15,6 +15,7 @@ class admingui
 		<td><b>Verification key</b></td>
 		<td><b>Device count</b></td>
 		<td><b>Valid until</b></td>
+		<td><b>Valid for</b></td>
 		<td><b>Comment</b></td>
 		<td><b>Devices</b></td>
 		<td><b>Drop voucher</b></td>
@@ -31,11 +32,14 @@ class admingui
 				$bgclass='darkbg';
 				$a=true;
 			}
+			$valid_for_d=round($dataset[$i]['valid_for'] / 24);
+			$valid_for_h=$dataset[$i]['valid_for'] % 24;
 			echo '<tr class="'.$bgclass.'">
 			<td>'.$dataset[$i]['voucher_id'].'</td>
 			<td>'.$dataset[$i]['verification_key'].'</td>
 			<td>'.$dataset[$i]['dev_count'].'</td>
 			<td>'.date('Y-m-d H:i',$dataset[$i]['valid_until']).'</td>
+			<td>'.$valid_for_d.'d '.$valid_for_h.'h</td>
 			<td>'.$dataset[$i]['comment'].'&nbsp;</td>
 			<td>';
 			


### PR DESCRIPTION
1. Voucher valid from the moment of the first device is connected, and not to create a voucher. When creating all vouchers expiry date 2 years from now.
For this I had to add a new column to the table. His name valid_for and it contains the validity of the voucher. In the first connection with this voucher field valid_until = current + valid_for.
2. Added sorting by valid_until the output.
3. Removed minutes when creating a voucher (for my task is not applicable). Please review this
4. Removed date from vaucher_id for user convenience